### PR TITLE
Updating docker to latest image to get #![feature(nonzero_leading_trailing_zeros)]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@
 version: 2.1
 
 defaults:
-  builder-install: &builder-install gcr.io/mobilenode-211420/builder-install:1_12
+  builder-install: &builder-install gcr.io/mobilenode-211420/builder-install:1_23
   default-environment: &default-environment
     RUST_BACKTRACE: 1
     SKIP_SLOW_TESTS: 1


### PR DESCRIPTION
CircleCi Prepare Cargo Cache and Save step is currently failing due to #![feature(nonzero_leading_trailing_zeros)] being considered unstable on the circleci docker image but it is out of date and should be updated.