### PR TITLE
Unstable library feature

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@
 version: 2.1
 
 defaults:
-  builder-install: &builder-install gcr.io/mobilenode-211420/builder-install:1_23
+  builder-install: &builder-install gcr.io/mobilenode-211420/builder-install:1_12
   default-environment: &default-environment
     RUST_BACKTRACE: 1
     SKIP_SLOW_TESTS: 1
@@ -219,6 +219,10 @@ jobs:
 
   # Build and lint in debug mode
   build-all-and-lint-debug:
+    parameters:
+      test_save_cache:
+        type: boolean
+        default: true
     executor: build-executor
     environment:
       << : *default-environment
@@ -236,7 +240,10 @@ jobs:
           command: |
             ./tools/lint.sh
       - when:
-          condition: { equal: [ << pipeline.git.branch >>, master ] }
+          condition:
+            or:
+             - { equal: [ << pipeline.git.branch >>, master ] }
+             - { equal: [ true, << pipeline.parameters.test_save_cache >>]}
           steps: [ save-cargo-cache ]
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,7 +243,7 @@ jobs:
           condition:
             or:
              - { equal: [ << pipeline.git.branch >>, master ] }
-             - { equal: [ true, << pipeline.parameters.test_save_cache >>]}
+             - { equal: [ true, << parameters.test_save_cache >>]}
           steps: [ save-cargo-cache ]
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,9 +236,7 @@ jobs:
           command: |
             ./tools/lint.sh
       - when:
-          condition:
-            or:
-             - { equal: [ << pipeline.git.branch >>, master ] }
+          condition: { equal: [ << pipeline.git.branch >>, master ] }
           steps: [ save-cargo-cache ]
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ commands:
             mkdir -p ~/.config
             cargo trim --directory "$(pwd)"
             # Clean dependencies not in the Cargo.lock
-            time cargo trim --orphan-clean
+            time cargo trim --orphan
             # Make sure all dependencies are downloaded, since there appears to be
             # a bug where cargo trim erroneously removes certain git repos.
             time cargo fetch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ commands:
           command: |
             set -x
             command -v cargo-install-update >/dev/null || cargo install cargo-update
-            command -v cargo-trim >/dev/null || cargo install cargo-trim
+            command -v cargo-trim >/dev/null || (rustup run --install stable cargo install cargo-trim)
             cargo install-update --all
             # Configure cargo-trim with the project's Cargo.lock files
             mkdir -p ~/.config

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,10 +219,6 @@ jobs:
 
   # Build and lint in debug mode
   build-all-and-lint-debug:
-    parameters:
-      test_save_cache:
-        type: boolean
-        default: true
     executor: build-executor
     environment:
       << : *default-environment
@@ -243,7 +239,6 @@ jobs:
           condition:
             or:
              - { equal: [ << pipeline.git.branch >>, master ] }
-             - { equal: [ true, << parameters.test_save_cache >>]}
           steps: [ save-cargo-cache ]
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@
 version: 2.1
 
 defaults:
-  builder-install: &builder-install gcr.io/mobilenode-211420/builder-install:1_12
+  builder-install: &builder-install gcr.io/mobilenode-211420/builder-install:1_23
   default-environment: &default-environment
     RUST_BACKTRACE: 1
     SKIP_SLOW_TESTS: 1


### PR DESCRIPTION
CircleCi Prepare Cargo Cache and Save step is currently failing due to #![feature(nonzero_leading_trailing_zeros)] being considered unstable. The fix for this seems to be to use the stable toolchain for cargo-trim. Additionally in the latest version of cargo-trim it seems that orphan-clean has been renamed to just orphan.