### PR TITLE
add additional test functions

### DIFF
--- a/mc-oblivious-ram/src/lib.rs
+++ b/mc-oblivious-ram/src/lib.rs
@@ -340,7 +340,8 @@ mod testing {
         });
     }
 
-    // Run the exercise oram consecutive tests for 20,000 rounds in 8192 sized z4 oram
+    // Run the exercise oram consecutive tests for 20,000 rounds in 8192 sized z4
+    // oram
     #[test]
     fn exercise_consecutive_path_oram_z4_8192() {
         run_with_several_seeds(|rng| {
@@ -381,7 +382,8 @@ mod testing {
         });
     }
 
-    // Run the exercise oram consecutive tests for 100,000 rounds in 1024 sized z4 oram
+    // Run the exercise oram consecutive tests for 100,000 rounds in 1024 sized z4
+    // oram
     #[test]
     #[cfg(not(debug_assertions))]
     fn exercise_consecutive_path_oram_z4_1024() {

--- a/mc-oblivious-ram/src/lib.rs
+++ b/mc-oblivious-ram/src/lib.rs
@@ -340,6 +340,19 @@ mod testing {
         });
     }
 
+    // Run the exercise oram consecutive tests for 20,000 rounds in 8192 sized z4 oram
+    #[test]
+    fn exercise_consecutive_path_oram_z4_8192() {
+        run_with_several_seeds(|rng| {
+            let mut maker = rng_maker(rng);
+            let mut rng = maker();
+            let mut oram = PathORAM4096Z4Creator::<RngType, HeapORAMStorageCreator>::create(
+                8192, STASH_SIZE, &mut maker,
+            );
+            testing::exercise_oram_consecutive(20_000, &mut oram, &mut rng);
+        });
+    }
+
     // Run the exercise oram tests for 50,000 rounds in 32768 sized z4 oram
     #[test]
     #[cfg(not(debug_assertions))]
@@ -365,6 +378,20 @@ mod testing {
                 131072, STASH_SIZE, &mut maker,
             );
             testing::exercise_oram(60_000, &mut oram, &mut rng);
+        });
+    }
+
+    // Run the exercise oram consecutive tests for 100,000 rounds in 1024 sized z4 oram
+    #[test]
+    #[cfg(not(debug_assertions))]
+    fn exercise_consecutive_path_oram_z4_1024() {
+        run_with_several_seeds(|rng| {
+            let mut maker = rng_maker(rng);
+            let mut rng = maker();
+            let mut oram = PathORAM4096Z4Creator::<RngType, HeapORAMStorageCreator>::create(
+                1024, STASH_SIZE, &mut maker,
+            );
+            testing::exercise_oram_consecutive(100_000, &mut oram, &mut rng);
         });
     }
 }

--- a/mc-oblivious-traits/src/testing.rs
+++ b/mc-oblivious-traits/src/testing.rs
@@ -44,7 +44,8 @@ where
     }
 }
 
-/// Exercise an ORAM by writing, reading, and rewriting, all locations consecutively
+/// Exercise an ORAM by writing, reading, and rewriting, all locations
+/// consecutively
 pub fn exercise_oram_consecutive<BlockSize, O, R>(mut num_rounds: usize, oram: &mut O, rng: &mut R)
 where
     BlockSize: ArrayLength<u8>,

--- a/mc-oblivious-traits/src/testing.rs
+++ b/mc-oblivious-traits/src/testing.rs
@@ -44,6 +44,32 @@ where
     }
 }
 
+/// Exercise an ORAM by writing, reading, and rewriting, all locations consecutively
+pub fn exercise_oram_consecutive<BlockSize, O, R>(mut num_rounds: usize, oram: &mut O, rng: &mut R)
+where
+    BlockSize: ArrayLength<u8>,
+    O: ORAM<BlockSize>,
+    R: RngCore + CryptoRng,
+{
+    let len = oram.len();
+    assert!(len != 0, "len is zero");
+    assert_eq!(len & (len - 1), 0, "len is not a power of two");
+    let mut expected = BTreeMap::<u64, A64Bytes<BlockSize>>::default();
+
+    while num_rounds > 0 {
+        let query = num_rounds as u64 & (len - 1);
+        let expected_ent = expected.entry(query).or_default();
+
+        oram.access(query, |val| {
+            assert_eq!(val, expected_ent);
+            rng.fill_bytes(val);
+            expected_ent.clone_from_slice(val.as_slice());
+        });
+
+        num_rounds -= 1;
+    }
+}
+
 /// Exercise an OMAP by writing, reading, accessing, and removing a
 /// progressively larger set of random locations
 pub fn exercise_omap<KeySize, ValSize, O, R>(mut num_rounds: usize, omap: &mut O, rng: &mut R)


### PR DESCRIPTION
this adds a version of exercise_path_oram that queries consecutive
locations over and over, rather than using the "progressive"
strategy.

the progressive stratey was good initially when we would find bugs
quickly when items are queried again, and it's also good for testing
very large ORAMs in a way that is interesting.

this strategy helps to answer questions posed in issue #12, like,
is it the case that when all items exist in the tree, there is no
space for any dummy blocks, due to our choices of parameters.
In case of such an issue, we would expect this test to fail when
the number of rounds is significantly larger than the size of the
ORAM, because with high probability when an item is mapped
there would be no space on the branch that it selects or in the
stash.